### PR TITLE
Add bower installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ and include it to your project by:
 var Stately = require('stately.js');
 ```
 
+Alternately, you can install Stately.js with `bower`:
+
+    $ bower install --save Stately.js
+
 In browsers you can include it directly by adding it to the document head section:
 
 ```html


### PR DESCRIPTION
It is case-sensitive in bower installation.

Follow up of #9

I failed to install it with bower like the way npm does. Googled and found out it has been taken care of already.