### PR TITLE
feat(on): support declarative `on` style API

### DIFF
--- a/Stately.js
+++ b/Stately.js
@@ -167,6 +167,22 @@
                     }
 
                     return this;
+                },
+
+                on: function on(action, event, callback) {
+                    var hook;
+
+                    if (typeof callback === 'undefined') {
+
+                        callback = event;
+
+                        event = undefined;
+
+                    }
+
+                    hook = (typeof event === 'undefined') ? action : action + event;
+
+                    this['on' + hook] = callback;
                 }
             },
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -183,6 +183,50 @@ var test = {
                 this.assert(onOPEN === true, 'Report correct event 6');
             }
         },
+
+        {
+            name: 'Hooks (using on).',
+            method: function () {
+
+                var onleaveCLOSED,
+                onenterCLOSED,
+                onCLOSED,
+                onOPEN;
+
+                door = Stately.machine({
+                    'OPEN': {
+                        close: function () {
+                            return this.CLOSED;
+                        }
+                    },
+                    'CLOSED': {
+                        open: function () {
+                            return this.OPEN;
+                        }
+                    }
+                });
+
+                door.on('leave', 'CLOSED', function () {
+                    onleaveCLOSED = true;
+                });
+
+                door.on('enter', 'CLOSED', function () {
+                    onenterCLOSED = true;
+                });
+
+                door.on('OPEN', function () {
+                    onOPEN = true;
+                });
+
+                this.assert(door.close().getMachineState() === 'CLOSED', 'Transition into a new state.');
+                this.assert(door.open().getMachineState() === 'OPEN', 'Transition into a new state.');
+                this.assert(door.close().getMachineState() === 'CLOSED', 'Transition into a new state.');
+                this.assert(onleaveCLOSED === true, 'Report correct event 1');
+                this.assert(onenterCLOSED === true, 'Report correct event 2');
+                this.assert(onOPEN === true, 'Report correct event 4');
+            }
+        },
+
         {
             name: 'Exceptions.',
             method: function () {


### PR DESCRIPTION
I believes this covers the use case presented in #19, though is rather naively implemented. This covers my need, but perhaps you guys could provide feedback on what you feel is missing.